### PR TITLE
Add operator to every websocket event

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ not require any acknowledgment). Receipts can also be manually queried from the
 Successful operations will also result in a more detailed event of the form
 `{event: string, id: string, data: any}`, with the following event types:
 
-* `token-pool` - Token pool created (outputs: poolId, author, type, namespace, name, clientId)
-* `token-mint` - Tokens minted (outputs: poolId, tokenIndex, to, amount)
-* `token-transfer` - Tokens transferred (outputs: poolId, tokenIndex, from, to, amount)
+* `token-pool` - Token pool created (outputs: poolId, operator, type, namespace, name, clientId)
+* `token-mint` - Tokens minted (outputs: poolId, tokenIndex, operator, to, amount)
+* `token-transfer` - Tokens transferred (outputs: poolId, tokenIndex, operator, from, to, amount)
 
 For these events, if multiple websocket clients are connected, only one will receive them.
 Each one _must_ be acknowledged by replying on the websocket with `{event: "ack", data: {id}}`.

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -162,7 +162,10 @@ export class TokenPoolEvent {
   clientId: string;
 
   @ApiProperty()
-  author: string;
+  author: string; // TODO: remove
+
+  @ApiProperty()
+  operator: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;
@@ -180,6 +183,9 @@ export class TokenMintEvent {
 
   @ApiProperty()
   amount: number;
+
+  @ApiProperty()
+  operator: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;
@@ -200,6 +206,9 @@ export class TokenTransferEvent {
 
   @ApiProperty()
   amount: number;
+
+  @ApiProperty()
+  operator: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -189,7 +189,8 @@ class TokenListener implements EventListener {
         ...unpackTokenData(data.data),
         poolId: parts.poolId,
         type: parts.isFungible ? TokenType.FUNGIBLE : TokenType.NONFUNGIBLE,
-        author: data.operator,
+        author: data.operator, // TODO: remove
+        operator: data.operator,
         transaction: {
           blockNumber: event.blockNumber,
           transactionIndex: event.transactionIndex,
@@ -214,6 +215,7 @@ class TokenListener implements EventListener {
           tokenIndex: parts.tokenIndex,
           to: data.to,
           amount: data.value,
+          operator: data.operator,
           transaction: {
             blockNumber: event.blockNumber,
             transactionIndex: event.transactionIndex,
@@ -235,6 +237,7 @@ class TokenListener implements EventListener {
           from: data.from,
           to: data.to,
           amount: data.value,
+          operator: data.operator,
           transaction: {
             blockNumber: event.blockNumber,
             transactionIndex: event.transactionIndex,

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -323,6 +323,7 @@ describe('AppController (e2e)', () => {
             poolId: 'F1',
             type: 'fungible',
             author: 'bob',
+            operator: 'bob',
             transaction: {
               blockNumber: '1',
               transactionIndex: '0x0',
@@ -371,6 +372,7 @@ describe('AppController (e2e)', () => {
             tokenIndex: '0',
             to: 'A',
             amount: 5,
+            operator: 'A',
             transaction: {
               blockNumber: '1',
               transactionIndex: '0x0',
@@ -415,6 +417,7 @@ describe('AppController (e2e)', () => {
             from: 'A',
             to: 'B',
             amount: 1,
+            operator: 'A',
             transaction: {
               blockNumber: '1',
               transactionIndex: '0x0',


### PR DESCRIPTION
All of the events from this contract include an `operator` indicating the address of the party that performed the operation. This just exposes that upward.

Note: previously the field was remapped to `author` on the pool creation event, but the plan is to standardize on `operator` for this interface. Will remove `author` after firefly core is adjusted to look at the new field.