### PR TITLE
Add arbitrary "data" input to all POST APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ calls, and maps ethconnect events to outgoing websocket events.
 APIs all reside under `/api/v1`, and websocket notifications can be received by
 connecting to `/api/ws`.
 
-* `POST /pool` - Create a new token pool (inputs: type, namespace, name, clientId)
-* `POST /mint` - Mint new tokens (inputs: poolId, to, amount)
-* `POST /transfer` - Transfer tokens (inputs: poolId, tokenIndex, from, to, amount)
+* `POST /pool` - Create a new token pool (inputs: type, data)
+* `POST /mint` - Mint new tokens (inputs: poolId, to, amount, data)
+* `POST /transfer` - Transfer tokens (inputs: poolId, tokenIndex, from, to, amount, data)
 * `GET /balance` - Get token balance (inputs: poolId, tokenIndex, account)
 
 All POST APIs are async and return 202 immediately with a response of the form
@@ -29,9 +29,9 @@ not require any acknowledgment). Receipts can also be manually queried from the
 Successful operations will also result in a more detailed event of the form
 `{event: string, id: string, data: any}`, with the following event types:
 
-* `token-pool` - Token pool created (outputs: poolId, operator, type, namespace, name, clientId)
-* `token-mint` - Tokens minted (outputs: poolId, tokenIndex, operator, to, amount)
-* `token-transfer` - Tokens transferred (outputs: poolId, tokenIndex, operator, from, to, amount)
+* `token-pool` - Token pool created (outputs: poolId, operator, type, data)
+* `token-mint` - Tokens minted (outputs: poolId, tokenIndex, operator, to, amount, data)
+* `token-transfer` - Tokens transferred (outputs: poolId, tokenIndex, operator, from, to, amount, data)
 
 For these events, if multiple websocket clients are connected, only one will receive them.
 Each one _must_ be acknowledged by replying on the websocket with `{event: "ack", data: {id}}`.

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -63,20 +63,24 @@ export class TokenPool {
   type: TokenType;
 
   @ApiProperty()
-  @IsNotEmpty()
-  namespace: string;
+  @IsOptional()
+  namespace?: string; // TODO: remove
 
   @ApiProperty()
-  @IsNotEmpty()
-  name: string;
+  @IsOptional()
+  name?: string; // TODO: remove
 
   @ApiProperty()
-  @IsNotEmpty()
-  clientId: string;
+  @IsOptional()
+  clientId?: string; // TODO: remove
 
   @ApiProperty()
   @IsOptional()
   requestId?: string;
+
+  @ApiProperty()
+  @IsOptional()
+  data?: string;
 }
 
 export class TokenMint {
@@ -96,6 +100,10 @@ export class TokenMint {
   @ApiProperty()
   @IsOptional()
   requestId?: string;
+
+  @ApiProperty()
+  @IsOptional()
+  data?: string;
 }
 
 export class TokenBalanceQuery {
@@ -142,6 +150,10 @@ export class TokenTransfer {
   @ApiProperty()
   @IsOptional()
   requestId?: string;
+
+  @ApiProperty()
+  @IsOptional()
+  data?: string;
 }
 
 // Websocket notifications
@@ -165,16 +177,19 @@ export class TokenPoolEvent {
   type: TokenType;
 
   @ApiProperty()
-  namespace: string;
+  namespace: string; // TODO: remove
 
   @ApiProperty()
-  name: string;
+  name: string; // TODO: remove
 
   @ApiProperty()
-  clientId: string;
+  clientId: string; // TODO: remove
 
   @ApiProperty()
   operator: string;
+
+  @ApiProperty()
+  data: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;
@@ -195,6 +210,9 @@ export class TokenMintEvent {
 
   @ApiProperty()
   operator: string;
+
+  @ApiProperty()
+  data: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;
@@ -218,6 +236,9 @@ export class TokenTransferEvent {
 
   @ApiProperty()
   operator: string;
+
+  @ApiProperty()
+  data: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -22,8 +22,9 @@ import { Event, EventStreamReply } from '../event-stream/event-stream.interfaces
 import {
   isFungible,
   packTokenId,
-  packTokenData,
   unpackTokenId,
+  encodeHex,
+  packTokenData,
   unpackTokenData,
 } from './tokens.util';
 import {
@@ -87,11 +88,15 @@ export class TokensService {
   }
 
   async createPool(dto: TokenPool): Promise<AsyncResponse> {
+    const namespace = dto.namespace ?? '';
+    const name = dto.name ?? '';
+    const clientId = dto.clientId ?? '';
+    const data = dto.data ?? '';
     const response = await this.http
       .post<EthConnectAsyncResponse>(
         `${this.instanceUrl}/create`,
         {
-          data: packTokenData(dto.namespace, dto.name, dto.clientId),
+          data: packTokenData(namespace, name, clientId, data),
           is_fungible: dto.type === TokenType.FUNGIBLE,
         },
         this.postOptions(dto.requestId),
@@ -110,7 +115,7 @@ export class TokensService {
             type_id: typeId,
             to: [dto.to],
             amounts: [dto.amount],
-            data: [0],
+            data: dto.data === undefined ? [0] : encodeHex(dto.data),
           },
           this.postOptions(dto.requestId),
         )
@@ -128,7 +133,7 @@ export class TokensService {
           {
             type_id: typeId,
             to,
-            data: [0],
+            data: dto.data === undefined ? [0] : encodeHex(dto.data),
           },
           this.postOptions(dto.requestId),
         )
@@ -158,7 +163,7 @@ export class TokensService {
           to: dto.to,
           id: packTokenId(dto.poolId, dto.tokenIndex),
           amount: dto.amount,
-          data: [0],
+          data: dto.data === undefined ? [0] : encodeHex(dto.data),
         },
         this.postOptions(dto.requestId),
       )

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -14,18 +14,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { packTokenId, packTokenData, unpackTokenId, unpackTokenData } from './tokens.util';
+import {
+  decodeHex,
+  encodeHex,
+  packTokenData,
+  packTokenId,
+  unpackTokenData,
+  unpackTokenId,
+} from './tokens.util';
 
 describe('Util', () => {
-  it('packTokenUri', () => {
-    expect(packTokenData('ns', 'name', 'id')).toEqual('0x6e73006e616d65006964');
+  it('encodeHex', () => {
+    expect(encodeHex('hello')).toEqual('0x68656c6c6f');
+    expect(encodeHex('')).toEqual('0x');
   });
 
-  it('unpackTokenUri', () => {
-    expect(unpackTokenData('0x6e73006e616d65006964')).toEqual({
+  it('decodeHex', () => {
+    expect(decodeHex('0x68656c6c6f')).toEqual('hello');
+    expect(decodeHex('')).toEqual('');
+    expect(decodeHex('0x')).toEqual('');
+    expect(decodeHex('0x0')).toEqual('');
+  });
+
+  it('packTokenData', () => {
+    expect(packTokenData('ns', 'name', 'id', 'test')).toEqual('0x6e73006e616d650069640074657374');
+    expect(packTokenData('', '', '', 'test')).toEqual('0x00000074657374');
+    expect(packTokenData('', '', '', '')).toEqual('0x000000');
+  });
+
+  it('unpackTokenData', () => {
+    expect(unpackTokenData('0x6e73006e616d650069640074657374')).toEqual({
       namespace: 'ns',
       name: 'name',
       clientId: 'id',
+      data: 'test',
+    });
+    expect(unpackTokenData('0x00000074657374')).toEqual({
+      namespace: '',
+      name: '',
+      clientId: '',
+      data: 'test',
+    });
+    expect(unpackTokenData('0x000000')).toEqual({
+      namespace: '',
+      name: '',
+      clientId: '',
+      data: '',
     });
   });
 

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -22,8 +22,8 @@ export function decodeHex(data: string) {
   return Buffer.from(data.replace('0x', ''), 'hex').toString('utf8');
 }
 
-export function packTokenData(namespace: string, name: string, client_id: string) {
-  return encodeHex([namespace, name, client_id].join('\0'));
+export function packTokenData(namespace: string, name: string, client_id: string, data: string) {
+  return encodeHex([namespace, name, client_id, data].join('\0'));
 }
 
 export function unpackTokenData(data: string) {
@@ -32,18 +32,19 @@ export function unpackTokenData(data: string) {
     namespace: parts[0],
     name: parts[1],
     clientId: parts[2],
+    data: parts[3],
   };
 }
 
-export function isFungible(pool_id: string) {
-  return pool_id[0] === 'F';
+export function isFungible(poolId: string) {
+  return poolId[0] === 'F';
 }
 
-export function packTokenId(pool_id: string, token_index = '0') {
+export function packTokenId(poolId: string, tokenIndex = '0') {
   return (
-    (BigInt(isFungible(pool_id) ? 0 : 1) << BigInt(255)) |
-    (BigInt(pool_id.substr(1)) << BigInt(128)) |
-    BigInt(token_index)
+    (BigInt(isFungible(poolId) ? 0 : 1) << BigInt(255)) |
+    (BigInt(poolId.substr(1)) << BigInt(128)) |
+    BigInt(tokenIndex)
   ).toString();
 }
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -143,7 +143,7 @@ describe('AppController (e2e)', () => {
     expect(http.post).toHaveBeenCalledWith(
       `${INSTANCE_URL}/create`,
       {
-        data: '0x746573746e7300746f6b656e310031',
+        data: '0x746573746e7300746f6b656e31003100',
         is_fungible: true,
       },
       {
@@ -176,7 +176,7 @@ describe('AppController (e2e)', () => {
     expect(http.post).toHaveBeenCalledWith(
       `${INSTANCE_URL}/create`,
       {
-        data: '0x746573746e7300746f6b656e310031',
+        data: '0x746573746e7300746f6b656e31003100',
         is_fungible: false,
       },
       OPTIONS,


### PR DESCRIPTION
The /pool API will also be migrated from taking separate parameters
for namespace/name/clientId and will instead require clients to pack
relevant info into "data".