### PR TITLE
Add curl to docker image for healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ADD solidity/ ./
 RUN npx truffle compile
 
 FROM node:14-alpine3.11
+RUN apk add curl
 WORKDIR /root
 ADD package*.json ./
 RUN npm install


### PR DESCRIPTION
`curl` is necessary to have in the Docker image so that the container can run its own health checks. Custom health checks are required so that the FireFly Core does not start up until after the tokens connector is already listening for WebSocket connections.